### PR TITLE
feat: add Azure Databricks private deployment with VNet injection

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -71,3 +71,19 @@ Deploy the ```foundry.bicep``` infrastructure as code:
 ```bash
 az deployment group create --resource-group <new-rg-name> --template-file foundry-basic.bicep --parameters vnetRgName="<new-rg-name-vnet>"
 ```
+
+### Steps for Azure Databricks
+
+Deploy the ```databricks.bicep``` infrastructure as code:
+
+```bash
+az deployment group create --resource-group <new-rg-name> --template-file databricks.bicep --parameters location=canadacentral vnetRgName="<new-rg-name-vnet>"
+```
+
+This deploys an Azure Databricks workspace with:
+- VNet injection (secure cluster connectivity) using `databricks-host-subnet` and `databricks-container-subnet`
+- Public network access disabled and no public IPs on cluster nodes
+- Private endpoint (`databricks_ui_api`) on the `pe-subnet`
+- Private DNS zone `privatelink.azuredatabricks.net` (set `createPrivateDnsZones=false` to skip)
+
+Prerequisite: the VNet must already be deployed (see *Initial set-up* above) — `vnet.bicep` provisions the two delegated Databricks subnets alongside `pe-subnet`.

--- a/infra/config.json
+++ b/infra/config.json
@@ -17,5 +17,11 @@
   "foundryName": "foundry-test-nodns",
   "foundryLocation": "canadaeast",
   "foundryProjectName": "foundry-test-nodns-proj",
+
+  "databricksName": "dbw-sail-dev",
+  "databricksSku": "premium",
+  "databricksHostSubnetName": "databricks-host-subnet",
+  "databricksContainerSubnetName": "databricks-container-subnet",
+
   "createPrivateDnsZones": false
 }

--- a/infra/config.prod.json
+++ b/infra/config.prod.json
@@ -17,5 +17,11 @@
   "foundryName": "foundry-canadaeast-sail-prod",
   "foundryLocation": "canadaeast",
   "foundryProjectName": "foundry-canadaeast-sail-prod-proj",
+
+  "databricksName": "dbw-sail-prod",
+  "databricksSku": "premium",
+  "databricksHostSubnetName": "databricks-host-subnet",
+  "databricksContainerSubnetName": "databricks-container-subnet",
+
   "createPrivateDnsZones": false
 }

--- a/infra/databricks.bicep
+++ b/infra/databricks.bicep
@@ -1,0 +1,144 @@
+/*
+  Azure Databricks workspace with VNet injection and private connectivity
+  
+  Description: 
+  - Creates an Azure Databricks workspace with VNet injection (secure cluster connectivity)
+  - Public network access disabled
+  - No public IPs on cluster nodes
+  - Private endpoint for UI and API access
+  - Private DNS zone for name resolution
+*/
+
+@description('Name of the Azure Databricks workspace')
+param databricksName string = 'dbw-sail-dev'
+
+@description('Location for all resources.')
+param location string = 'canadaeast'
+
+@description('The pricing tier of the Databricks workspace.')
+@allowed([
+  'standard'
+  'premium'
+])
+param pricingTier string = 'premium'
+
+@description('Name of the virtual network')
+param vnetName string = 'private-vnet'
+
+@description('Name of the private endpoint subnet')
+param peSubnetName string = 'pe-subnet'
+
+@description('Name of the Databricks host (public) subnet')
+param databricksHostSubnetName string = 'databricks-host-subnet'
+
+@description('Name of the Databricks container (private) subnet')
+param databricksContainerSubnetName string = 'databricks-container-subnet'
+
+@description('Name of virtual network resource group')
+param vnetRgName string
+
+@description('Create private DNS zones for private endpoints. Set to false if DNS zones already exist or are managed centrally.')
+param createPrivateDnsZones bool = true
+
+// Build resource IDs across RGs
+var vnetId = resourceId(vnetRgName, 'Microsoft.Network/virtualNetworks', vnetName)
+var peSubnetId = resourceId(vnetRgName, 'Microsoft.Network/virtualNetworks/subnets', vnetName, peSubnetName)
+var managedRgName = 'databricks-rg-${databricksName}-${uniqueString(databricksName, resourceGroup().id)}'
+var managedRgId = '${subscription().id}/resourceGroups/${managedRgName}'
+
+/*
+  Step 1: Create the Databricks workspace with VNet injection
+*/
+resource databricksWorkspace 'Microsoft.Databricks/workspaces@2024-05-01' = {
+  name: databricksName
+  location: location
+  sku: {
+    name: pricingTier
+  }
+  properties: {
+    managedResourceGroupId: managedRgId
+
+    // Networking
+    publicNetworkAccess: 'Disabled'
+    requiredNsgRules: 'NoAzureDatabricksRules'
+
+    parameters: {
+      customVirtualNetworkId: {
+        value: vnetId
+      }
+      customPublicSubnetName: {
+        value: databricksHostSubnetName
+      }
+      customPrivateSubnetName: {
+        value: databricksContainerSubnetName
+      }
+      enableNoPublicIp: {
+        value: true
+      }
+    }
+  }
+}
+
+/*
+  Step 2: Create a private endpoint for Databricks UI and API
+*/
+resource databricksPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+  name: '${databricksName}-private-endpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${databricksName}-private-link-service-connection'
+        properties: {
+          privateLinkServiceId: databricksWorkspace.id
+          groupIds: [
+            'databricks_ui_api'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+/*
+  Step 3: Create a private DNS zone for the private endpoint
+*/
+resource databricksPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = if (createPrivateDnsZones) {
+  name: 'privatelink.azuredatabricks.net'
+  location: 'global'
+}
+
+// Link DNS zone to VNet
+resource databricksDnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (createPrivateDnsZones) {
+  parent: databricksPrivateDnsZone
+  location: 'global'
+  name: 'databricks-link'
+  properties: {
+    virtualNetwork: {
+      id: vnetId
+    }
+    registrationEnabled: false
+  }
+}
+
+// DNS zone group for the private endpoint
+resource databricksDnsGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = if (createPrivateDnsZones) {
+  parent: databricksPrivateEndpoint
+  name: '${databricksName}-dns-group'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: '${databricksName}-dns-config'
+        properties: {
+          privateDnsZoneId: databricksPrivateDnsZone.id
+        }
+      }
+    ]
+  }
+  dependsOn: [
+    databricksDnsVnetLink
+  ]
+}

--- a/infra/databricks.bicep
+++ b/infra/databricks.bicep
@@ -13,7 +13,7 @@
 param databricksName string = 'dbw-sail-dev'
 
 @description('Location for all resources.')
-param location string = 'canadaeast'
+param location string = 'canadacentral'
 
 @description('The pricing tier of the Databricks workspace.')
 @allowed([

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -8,6 +8,7 @@
     - Virtual Network (optional, if it doesn't exist)
     - Azure Machine Learning workspace with dependencies
     - Microsoft Foundry (Azure AI Services) with GPT-4o deployment
+    - Azure Databricks workspace with VNet injection and private connectivity
 
 .PARAMETER ConfigFile
     Path to the configuration JSON file. Default: config.json
@@ -16,7 +17,7 @@
     Skip VNet deployment if it already exists
 
 .PARAMETER DeploymentType
-    Type of deployment: 'all', 'vnet', 'aml', 'foundry'
+    Type of deployment: 'all', 'vnet', 'aml', 'foundry', 'databricks'
 
 .PARAMETER SubscriptionId
     Azure subscription ID (optional, will use current subscription if not specified)
@@ -37,7 +38,7 @@ param(
     [switch]$SkipVNetDeployment,
     
     [Parameter(Mandatory=$false)]
-    [ValidateSet('all', 'vnet', 'aml', 'foundry')]
+    [ValidateSet('all', 'vnet', 'aml', 'foundry', 'databricks')]
     [string]$DeploymentType = 'all',
     
     [Parameter(Mandatory=$false)]
@@ -187,6 +188,35 @@ function Start-Deployment {
             Write-Status "Microsoft Foundry deployed successfully" "Success"
         } else {
             Write-Status "Microsoft Foundry deployment failed" "Error"
+            exit 1
+        }
+    }
+    
+    # Deploy Azure Databricks
+    if ($DeploymentType -eq 'all' -or $DeploymentType -eq 'databricks') {
+        Write-Status "Deploying Azure Databricks workspace..." "Info"
+        
+        $databricksDeploymentName = "databricks-deployment-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+        
+        az deployment group create `
+            --name $databricksDeploymentName `
+            --resource-group $config.resourceGroup `
+            --template-file databricks.bicep `
+            --parameters databricksName=$($config.databricksName) `
+            --parameters location=$($config.location) `
+            --parameters pricingTier=$($config.databricksSku) `
+            --parameters vnetName=$($config.vnetName) `
+            --parameters peSubnetName=$($config.subnetName) `
+            --parameters databricksHostSubnetName=$($config.databricksHostSubnetName) `
+            --parameters databricksContainerSubnetName=$($config.databricksContainerSubnetName) `
+            --parameters vnetRgName=$($config.vnetResourceGroup) `
+            --parameters createPrivateDnsZones=$($config.createPrivateDnsZones) `
+            --output none
+        
+        if ($LASTEXITCODE -eq 0) {
+            Write-Status "Azure Databricks workspace deployed successfully" "Success"
+        } else {
+            Write-Status "Azure Databricks deployment failed" "Error"
             exit 1
         }
     }

--- a/infra/modules/aml-workspace.bicep
+++ b/infra/modules/aml-workspace.bicep
@@ -69,9 +69,6 @@ resource amlWorkspace 'Microsoft.MachineLearningServices/workspaces@2023-10-01' 
     managedNetwork: {
       isolationMode: 'AllowInternetOutBound'
     }
-
-    // private link settings
-    sharedPrivateLinkResources: []
   }
   kind: amlType
 }

--- a/infra/vnet.bicep
+++ b/infra/vnet.bicep
@@ -3,7 +3,8 @@
   
   Description: 
   - Virtual network
-  - Subnet
+  - Subnet for private endpoints
+  - Subnets for Databricks VNet injection (host and container) with delegation and NSG
 */
 
 @description('Name of the virtual network')
@@ -11,6 +12,18 @@ param vnetName string = 'private-vnet'
 
 @description('Name of the private endpoint subnet')
 param peSubnetName string = 'pe-subnet'
+
+@description('Name of the Databricks host subnet')
+param databricksHostSubnetName string = 'databricks-host-subnet'
+
+@description('Name of the Databricks container subnet')
+param databricksContainerSubnetName string = 'databricks-container-subnet'
+
+// NSG for Databricks subnets (required for VNet injection)
+resource databricksNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: '${vnetName}-databricks-nsg'
+  location: resourceGroup().location
+}
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: vnetName
@@ -26,6 +39,40 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
         name: peSubnetName
         properties: {
           addressPrefix: '192.168.0.0/24'
+        }
+      }
+      {
+        name: databricksHostSubnetName
+        properties: {
+          addressPrefix: '192.168.1.0/24'
+          networkSecurityGroup: {
+            id: databricksNsg.id
+          }
+          delegations: [
+            {
+              name: 'databricks-delegation'
+              properties: {
+                serviceName: 'Microsoft.Databricks/workspaces'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: databricksContainerSubnetName
+        properties: {
+          addressPrefix: '192.168.2.0/24'
+          networkSecurityGroup: {
+            id: databricksNsg.id
+          }
+          delegations: [
+            {
+              name: 'databricks-delegation'
+              properties: {
+                serviceName: 'Microsoft.Databricks/workspaces'
+              }
+            }
+          ]
         }
       }
     ]

--- a/infra/vnet.parameters.json
+++ b/infra/vnet.parameters.json
@@ -7,6 +7,12 @@
     },
     "peSubnetName": {
       "value": "pe-subnet"
+    },
+    "databricksHostSubnetName": {
+      "value": "databricks-host-subnet"
+    },
+    "databricksContainerSubnetName": {
+      "value": "databricks-container-subnet"
     }
   }
 }


### PR DESCRIPTION
- Add databricks.bicep: new Bicep template for Azure Databricks workspace with VNet injection, public network access disabled, no public IPs on cluster nodes, private endpoint (databricks_ui_api), and conditional private DNS zone (privatelink.azuredatabricks.net)

- Update vnet.bicep: add dedicated NSG and two delegated subnets for Databricks VNet injection (databricks-host-subnet 192.168.1.0/24 and databricks-container-subnet 192.168.2.0/24) alongside existing pe-subnet

- Update vnet.parameters.json: add databricksHostSubnetName and databricksContainerSubnetName parameters

- Update config.json and config.prod.json: add databricksName, databricksSku, databricksHostSubnetName, databricksContainerSubnetName fields for dev and prod environments

- Update deploy.ps1: add 'databricks' to DeploymentType ValidateSet and implement Databricks deployment block following existing pattern

- Fix aml-workspace.bicep: remove empty sharedPrivateLinkResources array that caused ARM deployment failure ('No elements in sharedPrivateLinkResources')